### PR TITLE
Add optional Promtail container for logging with Loki to prom stack

### DIFF
--- a/infra-templates/prom/1/docker-compose.yml
+++ b/infra-templates/prom/1/docker-compose.yml
@@ -1,0 +1,66 @@
+version: '2'
+services:
+  node-exporter:
+    image: prom/node-exporter
+    network_mode: host
+    volumes:
+      - /:/host:ro,rslave
+    pid: host
+    command:
+      - --path.rootfs
+      - /host
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.global: 'true'
+  proxy:
+    image: manastech/promproxy
+    environment:
+      PROMPROXY_ENV_LABEL: ${PROMPROXY_ENV_LABEL}
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+    ports:
+      - ${PROMPROXY_PORT}:9999/tcp
+    labels:
+      io.rancher.container.dns: 'true'
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.global: 'true'
+  haproxy-exporter:
+    image: prom/haproxy-exporter
+    network_mode: host
+    command:
+      - --haproxy.scrape-uri=http://localhost:9000/haproxy_stats;csv
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.global: 'true'
+  rancher-exporter:
+    image: manastech/rancher-v1.6-prometheus-rancher-exporter
+    labels:
+      io.rancher.container.agent.role: environment
+      io.rancher.container.create_agent: 'true'
+      io.rancher.container.pull_image: always
+  docker-cluster-exporter:
+    privileged: true
+    image: instedd/docker-cluster-exporter
+    network_mode: host
+    volumes:
+      - /var/run/docker.sock:/var/run/docker.sock
+      - /sys:/host/sys
+    pid: host
+    labels:
+      io.rancher.container.pull_image: always
+      io.rancher.scheduler.global: 'true'
+
+  {{- if eq .Values.ENABLE_PROMTAIL "true" -}}
+  promtail:
+    privileged: true
+    image: manastech/promtail-rancher:2.8.4-1
+    environment:
+      LOKI_URL: ${LOKI_URL}
+      TENANT_ID: ${LOKI_TENANT_ID}
+      ENVIRONMENT: ${PROMPROXY_ENV_LABEL}
+    volumes:
+    - /var/run/docker.sock:/var/run/docker.sock
+    labels:
+      io.rancher.container.pull_image: always
+  {{- end -}}

--- a/infra-templates/prom/1/rancher-compose.yml
+++ b/infra-templates/prom/1/rancher-compose.yml
@@ -1,0 +1,29 @@
+.catalog:
+  name: Prometheus Agents
+  version: '0.2'
+  description: Stack to run Prometheus agents to monitor a Rancher environment
+  minimum_rancher_version: v1.5.0
+  questions:
+    - variable: PROMPROXY_ENV_LABEL
+      label: Environment name
+      required: true
+      type: string
+    - variable: PROMPROXY_PORT
+      label: Listening port
+      required: true
+      type: int
+      default: 9999
+    - variable: ENABLE_PROMTAIL
+      label: Enable pushing logs with Promtail?
+      required: true
+      type: boolean
+      default: false
+    - variable: LOKI_URL
+      label: Full URL for Loki server if Promtail is enabled (eg. http://loki:3100/loki/api/v1/push)
+      required: false
+      type: string
+      default: http://loki:3100/loki/api/v1/push
+    - variable: LOKI_TENANT_ID
+      label: Tenant ID to use for pushed logs if Promtail is enabled
+      required: false
+      type: string

--- a/infra-templates/prom/config.yml
+++ b/infra-templates/prom/config.yml
@@ -1,7 +1,7 @@
 name: Prometheus Agents
 description: |
   Stack to run Prometheus agents to monitor a Rancher environment
-version: '0.1'
+version: '0.2'
 category: Monitoring
 maintainer: Juan Wajnerman <waj@manas.tech>
 license: The MIT License


### PR DESCRIPTION
Add our custom version of promtail as a container to the prom stack to enable logs pushing to a Loki server. The customized version adds some labels reflecting the Rancher stack/service of the collected logs, as well as filtering system containers (eg. Rancher agent related services).